### PR TITLE
feature/sudoers pwrcfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - **GZ302EA-XS64** - 64GB RAM variant
 - **GZ302EA-XS32** - 32GB RAM variant
 
-> **🚀 Version 1.0.0 - Stable Release!** Complete hardware support with kernel 6.14+ compatibility, modern `pwrcfg` and `rrcfg` power/display management, and SPL/sPPT/fPPT architecture. Includes fixes for touchpad detection and suspend/resume gestures. **Required: Linux kernel 6.14+ minimum (6.17+ strongly recommended) for AMD XDNA NPU, Strix Halo optimizations, and WiFi stability.**
+> **🚀 Version 1.0.2 - Stable Release!** Complete hardware support with kernel 6.14+ compatibility, modern `pwrcfg` and `rrcfg` power/display management, and SPL/sPPT/fPPT architecture. Includes fixes for touchpad detection and suspend/resume gestures. Adds optional sudoers NOPASSWD for `pwrcfg`, improved kernel validation, and minor polish. **Required: Linux kernel 6.14+ minimum (6.17+ strongly recommended) for AMD XDNA NPU, Strix Halo optimizations, and WiFi stability.**
 
 ## ✨ Key Features
 

--- a/gz302-main.sh
+++ b/gz302-main.sh
@@ -1318,6 +1318,9 @@ MONITOR_EOF
 
     chmod +x /usr/local/bin/pwrcfg-monitor
     
+    # Reload systemd units to ensure new services are recognized
+    systemctl daemon-reload
+    
     systemctl enable pwrcfg-auto.service
     
     echo ""


### PR DESCRIPTION
- **Cleanup: remove unreachable code after error calls in kernel version check logic**
- **Polish: mktemp for sudoers temp, shellcheck annotations, warning() usage, version banner 1.0.2**
- **Refactor and polish: safer os-release sourcing, mktemp for sudoers, kernel check flow, module download warnings, FRAME_LIMITS fix, version banner**
- **Docs: README version to 1.0.2; Service: daemon-reload after creating pwrcfg units**
