### PR TITLE
remove leftover files

### DIFF
--- a/scripts/uninstall/gz302-uninstall.sh
+++ b/scripts/uninstall/gz302-uninstall.sh
@@ -85,6 +85,9 @@ main() {
     disable_service "pwrcfg-monitor.service"
     disable_service "pwrcfg-resume.service"
     
+    # Battery Management
+    disable_service "battery-charge-limit.service"
+
     # RGB Persistence
     disable_service "gz302-rgb-restore.service"
     disable_service "gz302-kbd-backlight-save.service"
@@ -108,6 +111,9 @@ main() {
     remove_file "/usr/share/icons/hicolor/scalable/apps/gz302-control-center.svg"
     remove_file "/usr/share/icons/hicolor/scalable/apps/gz302-power-manager.svg"
     
+    # Battery Management
+    remove_file "/usr/local/bin/set-battery-limit.sh"
+
     # RGB Tools
     remove_file "/usr/local/bin/gz302-rgb"
     remove_file "/usr/local/bin/gz302-rgb-bin"
@@ -140,12 +146,12 @@ main() {
     remove_dir "/etc/gz302"
     remove_dir "/var/lib/gz302"
     remove_dir "/var/log/gz302"
-    
+
     # Remove legacy config dirs
     remove_dir "/etc/gz302-tdp"
     remove_dir "/etc/gz302-refresh"
     remove_dir "/etc/gz302-rgb"
-    
+
     echo
     info "Removing system integration..."
     # Sudoers
@@ -157,12 +163,17 @@ main() {
     # Udev rules
     remove_file "/etc/udev/rules.d/99-gz302-rgb.rules"
     remove_file "/etc/udev/rules.d/99-gz302-keyboard.rules" # Legacy
+
+    # NetworkManager configuration
+    remove_file "/etc/NetworkManager/conf.d/wifi-powersave.conf"
+
     udevadm control --reload || true
     
     # Modprobe configs
     remove_file "/etc/modprobe.d/mt7925.conf"
     remove_file "/etc/modprobe.d/amdgpu.conf"
     remove_file "/etc/modprobe.d/hid-asus.conf"
+    remove_file "/etc/modprobe.d/i2c-hid-acpi-gz302.conf"
     remove_file "/etc/modprobe.d/cs35l41.conf"
     
     # ASUS Daemon override


### PR DESCRIPTION
# Pull Request

Remove the leftover files during the uninstallation.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, linting, etc.)

## Testing
Re-run the uninstallation and confirmed that there are no leftover gz302* files.

**Tested on:**
- [ ] Arch Linux / EndeavourOS / Manjaro
- [X] Ubuntu 24.04.3
- [ ] Fedora / Nobara
- [ ] OpenSUSE Tumbleweed / Leap

## Distribution Support
- [ ] Changes work on all 4 supported distribution families
- [ ] Arch-based implementation complete
- [X] Debian/Ubuntu-based implementation complete
- [ ] Fedora-based implementation complete
- [ ] OpenSUSE implementation complete