### PR TITLE
fix GZ302EA-Keyboard remap of copilot to insert

### DIFF
--- a/gz302-lib/input-manager.sh
+++ b/gz302-lib/input-manager.sh
@@ -443,7 +443,7 @@ input_apply_configuration() {
     # Reload udev
     systemd-hwdb update 2>/dev/null || true
     udevadm control --reload 2>/dev/null || true
-    
+    udevadm trigger 2>/dev/null || true
     return 0
 }
 
@@ -452,15 +452,15 @@ input_apply_configuration() {
 # Returns: 0 if created
 input_create_keyboard_remap() {
     cat > /etc/udev/hwdb.d/90-gz302-remap.hwdb <<'EOF'
-# Format evdev:input:b<bus_id>v<vendor_id>p<product_id>
+# Format evdev:input:b<bus_id>v<vendor_id>p<product_id>*
 
 # ** Note **
-# The line evdev:input:b0003v0B05p1866* may vary on your ASUS Laptop.
+# The line evdev:input:b0003v0B05p1A30* may vary on your ASUS Laptop.
 # Modify the <vendor_id> and <product_id> based on the output of this command to ensure remaps work:
-# $ lsusb | grep 'ASUSTek Computer, Inc. N-KEY Device' | awk -F'[: ]' '{print $7" "$8}' | tr '[:lower:]' '[:upper:]'
-# 0B05 18C6
-evdev:input:b0003v0B05p18C6:*
-  KEYBOARD_KEY_70072=ins
+# lsusb | grep 'GZ302EA-Keyboard'
+# Bus 003 Device 004: ID 0b05:1a30 ASUSTek Computer, Inc. GZ302EA-Keyboard
+evdev:input:b0003v0B05p1A30*
+  KEYBOARD_KEY_70072=insert
 EOF
     return 0
 }


### PR DESCRIPTION
Unfortunately, the previous PR #152 had errors. On my system, I also had keyd setup that was the one working; whereas, the udev setup was not. This fixes the pure `udev` setup.

# Pull Request

## Description
* fix device
```
lsusb | grep 'GZ302EA-Keyboard'
# Bus 003 Device 004: ID 0b05:1a30 ASUSTek Computer, Inc. GZ302EA-Keyboard
```
which gives this key:
```
evdev:input:b0003v0B05p1A30*
```
* fix keycode to `insert` (previously used `ins`, which was incorrect)
* apply uvadm trigger to take effect immediately (not enough to do `systemd-hwdb update` only, must trigger to simulate fresh device connection).

Reference
https://github.com/eudev-project/eudev/blob/master/hwdb/60-keyboard.hwdb

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Testing
After running the main script, test using `evtest` and `udevadm info`:

1. determine the correct event. Can vary. Look for `Asus Keyboard`:
```
# evtest
Available devices:
/dev/input/event16:	Asus Keyboard
/dev/input/event17:	Asus Keyboard
/dev/input/event27:	Asus Keyboard
```
2. describe the device. In my case, `event17`:
```
# udevadm info /dev/input/event17
E: DEVNAME=/dev/input/event17
...
E: KEYBOARD_KEY_70072=insert
...
E: ID_MODEL=GZ302EA-Keyboard
...
```
We can see that the scancode 70072 is mapped to keycode `insert`.
3. test: press `copilot` key
```
# evtest /dev/input/event17
...
type 4 (EV_MSC), code 4 (MSC_SCAN), value 70072
Event: time 1771468568.252813, type 1 (EV_KEY), code 110 (KEY_INSERT), value 1
```
4. in terminal, select some text, and press `copilot` key
the text should be copy/pasted.


**Tested on:**
- [X] Ubuntu 24.04 and 26.04 (dev)
