### PR TITLE
Fix indentation in command_center.py

### DIFF
--- a/command-center/src/command_center.py
+++ b/command-center/src/command_center.py
@@ -88,7 +88,7 @@ class DashboardWindow(QWidget):
 
         self.setup_ui()
         self.apply_styles()
-    self.apply_backend_state()
+        self.apply_backend_state()
 
     # ------------------------------------------------------------------
     # UI construction
@@ -626,7 +626,7 @@ class DashboardWindow(QWidget):
 
         self._update_profile_buttons()
         self._auto_btn.setChecked(self.power.is_auto_enabled())
-    self.apply_backend_state()
+        self.apply_backend_state()
 
 class CommandCenterApp(QSystemTrayIcon):
     def __init__(self, app):


### PR DESCRIPTION
# Pull Request

## Description
Fixes #174 

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement (refactoring, linting, etc.)

## Testing
Command center runs properly

**Device-profile changes:**
- [X] Not applicable
- [ ] I ran `bash tests/device-manager-detection.sh`
- [ ] I ran `bash scripts/sync-device-matrix.sh` and committed the generated updates

**Tested on:**
- [ ] Arch Linux / EndeavourOS / Manjaro
- [ ] Ubuntu / Pop!_OS / Linux Mint
- [X] Fedora / Nobara
- [ ] OpenSUSE Tumbleweed / Leap

**Test Results:**


## Code Quality Checklist
- [ ] My code passes `bash -n` syntax validation
- [ ] My code passes `shellcheck` with zero warnings
- [ ] I ran `bash tests/validate-version-sync.sh`
- [ ] I have followed the code style guidelines in CONTRIBUTING.md
- [ ] I have used proper quoting for all variables
- [ ] I have added `-r` flag to all `read` commands
- [ ] I have separated variable declarations from assignments

## Distribution Support
- [ ] Changes work on all 4 supported distribution families
- [ ] Arch-based implementation complete
- [ ] Debian/Ubuntu-based implementation complete
- [ ] Fedora-based implementation complete
- [ ] OpenSUSE implementation complete

## Documentation
- [ ] I have updated relevant documentation (README.md, CONTRIBUTING.md, etc.)
- [ ] I have synced generated device-matrix blocks if supported-device data changed
- [ ] I have added version numbers where applicable
- [ ] I have updated CHANGELOG.md for this version bump
- [ ] Code comments are clear and follow existing style

## Additional Notes

## Related Issues

